### PR TITLE
esn-frontend-common-libs#78: Marked 'admin.domain.general' as the default state

### DIFF
--- a/src/linagora.esn.admin/app/app.routes.js
+++ b/src/linagora.esn.admin/app/app.routes.js
@@ -158,7 +158,8 @@ angular.module('linagora.esn.admin')
           'root@admin': {
             template: '<admin-general />'
           }
-        }
+        },
+        default: true
       })
       .state('admin.domain.oauth', {
         url: '/oauth',


### PR DESCRIPTION
Partially resolves https://github.com/OpenPaaS-Suite/esn-frontend-common-libs/issues/78. Please also refer to https://github.com/OpenPaaS-Suite/esn-frontend-common-libs/pull/87.

- Demo: _to be updated..._