### PR TITLE
esn-frontend-inbox#143: Now uses the new jamesApiClient factory that uses esn-api-client

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
       }
 
       steps {
-        sh 'npm install'
+        sh 'npm install -f'
         sh 'npm run lint'
         sh 'npm run test'
       }

--- a/src/linagora.esn.admin/app/maintenance/james/admin-maintenance-james.controller.js
+++ b/src/linagora.esn.admin/app/maintenance/james/admin-maintenance-james.controller.js
@@ -1,16 +1,13 @@
 'use strict';
 
-const jamesApi = require('esn-api-client/src/api/james');
-
 angular.module('linagora.esn.james')
   .controller('adminMaintenanceJamesController', adminMaintenanceJamesController);
 
 function adminMaintenanceJamesController(
   asyncAction,
-  esnApiClient
+  jamesApiClient
 ) {
   const self = this;
-  const jamesApiClient = jamesApi.default(esnApiClient);
 
   self.synchronizeDomains = synchronizeDomains;
 

--- a/src/linagora.esn.admin/app/maintenance/james/admin-maintenance-james.controller.spec.js
+++ b/src/linagora.esn.admin/app/maintenance/james/admin-maintenance-james.controller.spec.js
@@ -4,13 +4,14 @@
 /* global sinon: false */
 
 const { expect } = chai;
-const jamesApi = require('esn-api-client/src/api/james');
 
 describe('The adminMaintenanceJamesController', function() {
   let $controller, $rootScope, $scope;
-  let jamesApiClient, sandbox;
+  let jamesApiClientMock;
 
   beforeEach(function() {
+    jamesApiClientMock = {};
+
     angular.mock.module('linagora.esn.admin');
     angular.mock.module(function($provide) {
       $provide.factory('asyncAction', function() {
@@ -18,6 +19,7 @@ describe('The adminMaintenanceJamesController', function() {
           action();
         };
       });
+      $provide.factory('jamesApiClient', function() { return jamesApiClientMock; });
     });
 
     angular.mock.inject(function(
@@ -27,20 +29,6 @@ describe('The adminMaintenanceJamesController', function() {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
     });
-  });
-
-  beforeEach(function() {
-    sandbox = sinon.sandbox.create();
-
-    jamesApiClient = {};
-
-    sandbox.stub(jamesApi, 'default', function() {
-      return jamesApiClient;
-    });
-  });
-
-  afterEach(function() {
-    sandbox.restore();
   });
 
   function initController(scope) {
@@ -55,13 +43,13 @@ describe('The adminMaintenanceJamesController', function() {
 
   describe('The synchronizeDomains fn', function() {
     it('should call James client to synchronize domains', function() {
-      jamesApiClient.syncDomains = sinon.stub();
+      jamesApiClientMock.syncDomains = sinon.stub();
 
       const controller = initController();
 
       controller.synchronizeDomains();
 
-      expect(jamesApiClient.syncDomains).to.have.been.calledOnce;
+      expect(jamesApiClientMock.syncDomains).to.have.been.calledOnce;
     });
   });
 });

--- a/src/linagora.esn.admin/app/modules/james/james-config-form.controller.js
+++ b/src/linagora.esn.admin/app/modules/james/james-config-form.controller.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const jamesApi = require('esn-api-client/src/api/james');
-
 angular.module('linagora.esn.admin')
   .controller('jamesConfigFormController', jamesConfigFormController);
 
@@ -15,10 +13,9 @@ function jamesConfigFormController(
   $q,
   session,
   jamesQuotaHelpers,
-  esnApiClient
+  jamesApiClient
 ) {
   const self = this;
-  const jamesApiClient = jamesApi.default(esnApiClient);
 
   self.$onInit = $onInit;
   self.onServerUrlChange = onServerUrlChange;

--- a/src/linagora.esn.admin/app/modules/james/james-config-form.controller.spec.js
+++ b/src/linagora.esn.admin/app/modules/james/james-config-form.controller.spec.js
@@ -28,7 +28,6 @@ describe('The jamesConfigFormController', function() {
     angular.mock.inject(function(
       _$controller_,
       _$rootScope_,
-      _$q_,
       _session_
     ) {
       $controller = _$controller_;

--- a/test/config/mocks/injector.js
+++ b/test/config/mocks/injector.js
@@ -2,6 +2,7 @@ angular.module('esn.test.injector', []).run(function($q) {
   window.$q = $q;
 });
 
-beforeEach(angular.mock.module('esn.test.injector'));
-
-window.$q = angular.injector(['ng']).get('$q');
+beforeEach(function() {
+  angular.mock.module('esn.test.injector');
+  window.$q = angular.injector(['ng']).get('$q');
+});


### PR DESCRIPTION
Partially resolves https://github.com/OpenPaaS-Suite/esn-frontend-inbox/issues/143. Please also refer to https://github.com/OpenPaaS-Suite/esn-frontend-inbox/pull/151 because this PR needs to be merged after that PR.

The CI is expected to fail until https://github.com/OpenPaaS-Suite/esn-frontend-inbox/pull/151 is merged.

Tested all the James-related features with `npm run serve:prod`.